### PR TITLE
Edit page content

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -16,7 +16,7 @@ If you would like to donate a problem that could be used for our competition or 
 Email: [sums@st-andrews.ac.uk](mailto:sums@st-andrews.ac.uk)
 
 Address:  \
-University of St Andrews \
-College Gate \
+Students' Association \
+St Mary's Place \
 St Andrews \
-KY16 9AJ  
+KY16 9UZ  

--- a/_pages/registrations.md
+++ b/_pages/registrations.md
@@ -3,7 +3,9 @@ permalink: /registrations/
 title: "Registrations"
 ---
 
-The following [form](https://forms.office.com/r/uCbPBaezQ0) can be used by teams of two to four members, or by individuals that wish to be assigned a team. We will aim to make teams consisting of individuals from different universities to encourage collaboration.  
+The form below can be used by teams of two to four members, or by individuals that wish to be assigned a team. We will aim to make teams consisting of individuals from different universities to encourage collaboration.  
+
+<iframe width="640px" height= "480px" src= "https://forms.office.com/Pages/ResponsePage.aspx?id=yyZW-KgN00mqWGTvZ47wGgdeFf0yfvtGmBPuOF0mH0tUODBSVUhUSTdQN1VLM1U4WTNPWDkxVTZNMy4u&embed=true" frameborder= "0" marginwidth= "0" marginheight= "0" style= "border: none; max-width:100%; max-height:100vh" allowfullscreen webkitallowfullscreen mozallowfullscreen msallowfullscreen> </iframe>
 
 Signups will close at **23:59 GMT on Saturday 12th February**. 
 


### PR DESCRIPTION
Correct the address so it points to the Union (SUMS' registered address), and embed the signup form, as opposed to having a hyperlink.